### PR TITLE
Always use timestamp

### DIFF
--- a/draft-ietf-opsawg-pcap.md
+++ b/draft-ietf-opsawg-pcap.md
@@ -121,8 +121,8 @@ The meaning of the fields in the File Header is:
 Magic Number (32 bits):
 : an unsigned magic number, whose value is either the hexadecimal number
 0xA1B2C3D4 or the hexadecimal number 0xA1B23C4D.
-: If the value is 0xA1B2C3D4, time stamps in Packet Records (see Figure
-2) are in seconds and microseconds; if it is 0xA1B23C4D, time stamps in
+: If the value is 0xA1B2C3D4, timestamps in Packet Records (see Figure
+2) are in seconds and microseconds; if it is 0xA1B23C4D, timestamps in
 Packet Records are in seconds and nanoseconds.
 : These numbers can be used to distinguish sessions that have been
 written on little-endian machines from the ones written on big-endian

--- a/draft-ietf-opsawg-pcaplinktype.md
+++ b/draft-ietf-opsawg-pcaplinktype.md
@@ -289,7 +289,7 @@ DLT values are associated with specific operation system captures, and are opera
 |LINKTYPE_PROFIBUS_DL|257|PROFIBUS data link layer packets, as specified by IEC standard 61158-4-3, beginning with the start delimiter, ending with the end delimiter, and including all octets between them.
 |LINKTYPE_PKTAP|258|Apple PKTAP capture encapsulation
 |LINKTYPE_EPON|259|Ethernet-over-passive-optical-network packets, starting with the last 6 octets of the modified preamble as specified by 65.1.3.2 Transmit in Clause 65 of Section 5 of IEEE 802.3 , followed immediately by an Ethernet frame.
-|LINKTYPE_IPMI_HPM_2|260|IPMI trace packets, as specified by Table 3-20 Trace Data Block Format in the PICMG HPM.2 specification The time stamps for packets in this format must match the time stamps in the Trace Data Blocks.
+|LINKTYPE_IPMI_HPM_2|260|IPMI trace packets, as specified by Table 3-20 Trace Data Block Format in the PICMG HPM.2 specification The timestamps for packets in this format must match the timestamps in the Trace Data Blocks.
 |LINKTYPE_ZWAVE_R1_R2|261|Z-Wave RF profile R1 and R2 packets , as specified by ITU-T Recommendation G.9959 , with some MAC layer fields moved.
 |LINKTYPE_ZWAVE_R3|262|Z-Wave RF profile R3 packets , as specified by ITU-T Recommendation G.9959 , with some MAC layer fields moved.
 |LINKTYPE_WATTSTOPPER_DLM|263|Formats for WattStopper Digital Lighting Management (DLM) and Legrand Nitoo Open protocol common packet structure captures.

--- a/linktypes.csv
+++ b/linktypes.csv
@@ -85,7 +85,7 @@ LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR,256,DLT_BLUETOOTH_LE_LL_WITH_PHDR,"Bluetooth 
 LINKTYPE_PROFIBUS_DL,257,DLT_PROFIBUS_DL,"PROFIBUS data link layer packets, as specified by IEC standard 61158-4-3, beginning with the start delimiter, ending with the end delimiter, and including all octets between them."
 LINKTYPE_PKTAP,258,DLT_PKTAP,"Apple PKTAP capture encapsulation ."
 LINKTYPE_EPON,259,DLT_EPON,"Ethernet-over-passive-optical-network packets, starting with the last 6 octets of the modified preamble as specified by 65.1.3.2 ""Transmit"" in Clause 65 of Section 5 of IEEE 802.3 , followed immediately by an Ethernet frame."
-LINKTYPE_IPMI_HPM_2,260,DLT_IPMI_HPM_2,"IPMI trace packets, as specified by Table 3-20 ""Trace Data Block Format"" in the PICMG HPM.2 specification . The time stamps for packets in this format must match the time stamps in the Trace Data Blocks."
+LINKTYPE_IPMI_HPM_2,260,DLT_IPMI_HPM_2,"IPMI trace packets, as specified by Table 3-20 ""Trace Data Block Format"" in the PICMG HPM.2 specification . The timestamps for packets in this format must match the timestamps in the Trace Data Blocks."
 LINKTYPE_ZWAVE_R1_R2,261,DLT_ZWAVE_R1_R2,"Z-Wave RF profile R1 and R2 packets , as specified by ITU-T Recommendation G.9959 , with some MAC layer fields moved."
 LINKTYPE_ZWAVE_R3,262,DLT_ZWAVE_R3,"Z-Wave RF profile R3 packets , as specified by ITU-T Recommendation G.9959 , with some MAC layer fields moved."
 LINKTYPE_WATTSTOPPER_DLM,263,DLT_WATTSTOPPER_DLM,"Formats for WattStopper Digital Lighting Management (DLM) and Legrand Nitoo Open protocol common packet structure captures."

--- a/linktypes.txt
+++ b/linktypes.txt
@@ -83,7 +83,7 @@
 |LINKTYPE_PROFIBUS_DL|257|PROFIBUS data link layer packets, as specified by IEC standard 61158-4-3, beginning with the start delimiter, ending with the end delimiter, and including all octets between them.
 |LINKTYPE_PKTAP|258|Apple PKTAP capture encapsulation
 |LINKTYPE_EPON|259|Ethernet-over-passive-optical-network packets, starting with the last 6 octets of the modified preamble as specified by 65.1.3.2 Transmit in Clause 65 of Section 5 of IEEE 802.3 , followed immediately by an Ethernet frame.
-|LINKTYPE_IPMI_HPM_2|260|IPMI trace packets, as specified by Table 3-20 Trace Data Block Format in the PICMG HPM.2 specification The time stamps for packets in this format must match the time stamps in the Trace Data Blocks.
+|LINKTYPE_IPMI_HPM_2|260|IPMI trace packets, as specified by Table 3-20 Trace Data Block Format in the PICMG HPM.2 specification The timestamps for packets in this format must match the timestamps in the Trace Data Blocks.
 |LINKTYPE_ZWAVE_R1_R2|261|Z-Wave RF profile R1 and R2 packets , as specified by ITU-T Recommendation G.9959 , with some MAC layer fields moved.
 |LINKTYPE_ZWAVE_R3|262|Z-Wave RF profile R3 packets , as specified by ITU-T Recommendation G.9959 , with some MAC layer fields moved.
 |LINKTYPE_WATTSTOPPER_DLM|263|Formats for WattStopper Digital Lighting Management (DLM) and Legrand Nitoo Open protocol common packet structure captures.


### PR DESCRIPTION
This change avoids mixing of 'time stamp' and 'timestamp'.

s/time stamps/timestamps/g

In the RFCs, there are ~23 times more 'timestamp' than 'time stamp'.