### PR TITLE
add new secrets type for OPC UA protocol

### DIFF
--- a/draft-ietf-opsawg-pcapng.md
+++ b/draft-ietf-opsawg-pcapng.md
@@ -2018,7 +2018,7 @@ The following is a list of Secrets Types.
 
 {: indent='8'}
 0x55414b4c:
-: OPC UA Key Log.
+: [OPC UA](https://opcfoundation.org/about/opc-technologies/opc-ua) Key Log.
   Every line consists of a key/value pair separated by a colon and one space ('`: `').
   Every line must be terminated by a linefeed ('`\n`').
   The key name is composed of four parts separated by underscores ('`_`').
@@ -2052,6 +2052,10 @@ The following is a list of Secrets Types.
   * AES-256-CBC:
     - IV Length: 16 bytes
     - Key Length: 32 bytes
+
+   More details on OPC UA Security can be found in the [OPC UA Specification Part 6 - Mappings](https://opcfoundation.org/developer-tools/specifications-unified-architecture),
+   the security policies are defined in [OPC UA Specification Part 7 - Profiles](https://opcfoundation.org/developer-tools/specifications-unified-architecture),
+   or can be found online on the [Profile Reporting website](https://opcfoundation.org/profilereporting).
 
 {: vspace='0'}
 

--- a/draft-ietf-opsawg-pcapng.md
+++ b/draft-ietf-opsawg-pcapng.md
@@ -2023,13 +2023,20 @@ The following is a list of Secrets Types.
   Every line must be terminated by a linefeed ('`\n`').
   The key name is composed of four parts separated by underscores ('`_`').
 
-  1. Keyset Name: Either 'server' or 'client'.
+  * Keyset Name: Either 'server' or 'client'.
 
-  2. Key Material Type: Either be 'iv' (initialization vector) or 'key' (AES key).
+      The Client keys are used to secure Messages sent by the Client. The
+      Server keys are used to secure Messages sent by the Server.
 
-  3. Secure Channel ID: Encoded as decimal value.
+  * Key Material Type:
 
-  4. Token ID: Encoded as decimal value.
+    - 'iv': initialization vector
+    - 'key': AES key
+    - 'siglen': signature length in bytes. This depdends on the used security policy.
+
+  * Secure Channel ID: Encoded as decimal value.
+
+  * Token ID: Encoded as decimal value.
 
   The *value* contains the key data encoded as hexadecimal string with upper
   case letters.  To create a valid keyset, four entries for one combination of

--- a/draft-ietf-opsawg-pcapng.md
+++ b/draft-ietf-opsawg-pcapng.md
@@ -2017,6 +2017,39 @@ The following is a list of Secrets Types.
 
 
 {: indent='8'}
+0x55414b4c:
+: OPC UA Key Log.
+  Every line consists of a key/value pair separated by a colon and one space ('`: `').
+  Every line must be terminated by a linefeed ('`\n`').
+  The key name is composed of four parts separated by underscores ('`_`').
+
+  1. Keyset Name: Either 'server' or 'client'.
+
+  2. Key Material Type: Either be 'iv' (initialization vector) or 'key' (AES key).
+
+  3. Secure Channel ID: Encoded as decimal value.
+
+  4. Token ID: Encoded as decimal value.
+
+  The *value* contains the key data encoded as hexadecimal string with upper
+  case letters.  To create a valid keyset, four entries for one combination of
+  secure channel ID and token ID are required. These entries include 'iv' and
+  'key' for both 'server' and 'client'.
+
+  Currently, AES-128-CBC and AES-256-CBC are supported encryption algorithms:
+
+  * AES-128-CBC:
+    - IV Length: 16 bytes
+    - Key Length: 16 bytes
+
+  * AES-256-CBC:
+    - IV Length: 16 bytes
+    - Key Length: 32 bytes
+
+{: vspace='0'}
+
+
+{: indent='8'}
 0x57474b4c:
 : WireGuard Key Log.
   Every line consists of the key type, equals sign ('='), and the
@@ -2061,7 +2094,6 @@ The following is a list of Secrets Types.
   new Keys. If the APS Key changes for an existing link, it is
   contained in a new DSB with the new APS Key.
 {: vspace='0'}
-
 
 
 ~~~~

--- a/draft-ietf-opsawg-pcapng.md
+++ b/draft-ietf-opsawg-pcapng.md
@@ -2053,8 +2053,8 @@ The following is a list of Secrets Types.
     - IV Length: 16 bytes
     - Key Length: 32 bytes
 
-   More details on OPC UA Security can be found in the [OPC UA Specification Part 6 - Mappings](https://opcfoundation.org/developer-tools/specifications-unified-architecture),
-   the security policies are defined in [OPC UA Specification Part 7 - Profiles](https://opcfoundation.org/developer-tools/specifications-unified-architecture),
+   More details on OPC UA Security can be found in the [OPC UA Specification Part 6 - Mappings](https://opcfoundation.org/developer-tools/documents/view/163),
+   the security policies are defined in [OPC UA Specification Part 7 - Profiles](https://opcfoundation.org/developer-tools/documents/view/164),
    or can be found online on the [Profile Reporting website](https://opcfoundation.org/profilereporting).
 
 {: vspace='0'}


### PR DESCRIPTION
This new type allows embedding UA secrets log into PCAPNG files to easily distribute Wireshark capture files with the according secrets. This branch: https://gitlab.com/gergap/wireshark/-/tree/opcua_pcang_keylogfile contains the necessary changes in Wireshark to support this new type.