### PR TITLE
pcapng: Replace dead link to TLS key log page

### DIFF
--- a/draft-ietf-opsawg-pcapng.md
+++ b/draft-ietf-opsawg-pcapng.md
@@ -2058,7 +2058,7 @@ The following is a list of Secrets Types.
 {: indent='8'}
 0x544c534b:
 : TLS Key Log. This
-  format is described at [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format). Every line MUST be properly terminated with
+  format is described at [NSS Key Log Format](https://udn.realityripple.com/docs/Mozilla/Projects/NSS/Key_Log_Format). Every line MUST be properly terminated with
   either carriage return and linefeed ('\r\n') or linefeed ('\n').
   Tools MUST be able to handle both line endings.
 {: vspace='0'}


### PR DESCRIPTION
The Mozilla Developer Network Web Docs site reorganized and removed a lot of the historical and legacy docs. The archive for the documentation for NSS is broken and doesn't have the TLS key log page: https://firefox-source-docs.mozilla.org/security/nss/index.html

Link to a backup archive site with the same content.